### PR TITLE
Feature/handle windows paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-variable",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "define CSS custom properties (variables) in JS",
   "main": "./dist/index.js",
   "exports": {

--- a/swc/Cargo.lock
+++ b/swc/Cargo.lock
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -920,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "relative-path"
@@ -1212,7 +1212,9 @@ name = "swc-plugin-css-variable"
 version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
+ "lazy_static",
  "pathdiff",
+ "regex",
  "serde",
  "serde_json",
  "sha3",

--- a/swc/Cargo.toml
+++ b/swc/Cargo.toml
@@ -21,6 +21,8 @@ swc_plugin = "0.49.0"
 sha3 = "0.10.1"
 base64 = "0.13.0"
 pathdiff = "0.2.1"
+regex = "1.5.6"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 swc_ecma_parser = "0.102.4"

--- a/swc/src/lib.rs
+++ b/swc/src/lib.rs
@@ -20,7 +20,7 @@ pub struct Config {
     #[serde(default = "bool::default")]
     pub display_name: bool,
     /// The hash for a css-variable depends on the file name including createVar().
-    /// To ensure that the hash is consistent accross multiple systems the relative path 
+    /// To ensure that the hash is consistent accross multiple systems the relative path
     /// from the base dir to the source file is used.
     #[serde()]
     pub base_path: String,
@@ -169,7 +169,13 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     let context: Context =
         serde_json::from_str(&metadata.transform_context).expect("failed to parse plugin context");
 
-    let hashed_filename = hash(relative_posix_path(&config.base_path, &context.filename.unwrap_or_else(|| "jantimon".to_owned())), 5);
+    let hashed_filename = hash(
+        relative_posix_path(
+            &config.base_path,
+            &context.filename.unwrap_or_else(|| "jantimon".to_owned()),
+        ),
+        5,
+    );
 
     program.fold_with(&mut as_folder(TransformVisitor::new(
         config,
@@ -275,7 +281,10 @@ mod tests {
 
     test!(
         swc_ecma_parser::Syntax::default(),
-        |_| transform_visitor(Config { display_name: true, base_path: "/".to_owned() }),
+        |_| transform_visitor(Config {
+            display_name: true,
+            base_path: "/".to_owned()
+        }),
         adds_camel_case_variable_name_with_display_name,
         r#"import {createVar} from "css-variable";
         const camelCase = createVar();"#,
@@ -285,7 +294,10 @@ mod tests {
 
     test!(
         swc_ecma_parser::Syntax::default(),
-        |_| transform_visitor(Config { display_name: true, base_path: "/".to_owned() }),
+        |_| transform_visitor(Config {
+            display_name: true,
+            base_path: "/".to_owned()
+        }),
         adds_variable_name_with_display_name,
         r#"import {createVar} from "css-variable";
         const primary = createVar();

--- a/swc/src/lib.rs
+++ b/swc/src/lib.rs
@@ -183,11 +183,13 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     )))
 }
 
-/// Returns a relative posix path from the base_path to the filename
-/// e.g. "/foo/", "/bar/baz.txt" -> "../bar/baz.txt"
-/// e.g. "C:\foo\", "C:\foo\baz.txt" -> "../bar/baz.txt"
+/// Returns a relative POSIX path from the `base_path` to the filename.
 ///
-/// The format of base_path and filename must match the current os
+/// For example:
+/// - "/foo/", "/bar/baz.txt" -> "../bar/baz.txt"
+/// - "C:\foo\", "C:\foo\baz.txt" -> "../bar/baz.txt"
+///
+/// The format of `base_path` and `filename` must match the current OS.
 fn relative_posix_path(base_path: &String, filename: &String) -> String {
     let normalized_base_path = convert_path_to_posix(base_path);
     let normalized_filename = convert_path_to_posix(filename);
@@ -201,9 +203,11 @@ fn relative_posix_path(base_path: &String, filename: &String) -> String {
     return path_parts.join("/");
 }
 
-/// Returns the path converted to a posix path (naive approach)
-/// e.g. "C:\foo\bar" -> "c/foo/bar"
-/// e.g. "/foo/bar" -> "/foo/bar"
+/// Returns the path converted to a POSIX path (naive approach).
+///
+/// For example:
+/// - "C:\foo\bar" -> "c/foo/bar"
+/// - "/foo/bar" -> "/foo/bar"
 fn convert_path_to_posix(path: &String) -> String {
     lazy_static! {
         static ref PATH_REPLACEMENT_REGEX: Regex = Regex::new(r":\\|\\").unwrap();

--- a/swc/src/lib.rs
+++ b/swc/src/lib.rs
@@ -310,12 +310,21 @@ mod tests {
     );
 
     #[test]
-    fn test_relative_path() {
+    fn test_relative_path_unix() {
         assert_eq!(
             relative_posix_path(&String::from("/foo/"), &String::from("/bar/baz.txt")),
             "../bar/baz.txt"
         );
     }
+
+    #[test]
+    fn test_relative_path_windows() {
+        assert_eq!(
+            relative_posix_path(&String::from(r"C:\foo\"), &String::from(r"C:\bar\baz.txt")),
+            "../bar/baz.txt"
+        );
+    }
+
     #[test]
     fn test_convert_unix_path() {
         assert_eq!(

--- a/swc/src/lib.rs
+++ b/swc/src/lib.rs
@@ -190,7 +190,7 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
 /// - "C:\foo\", "C:\foo\baz.txt" -> "../bar/baz.txt"
 ///
 /// The format of `base_path` and `filename` must match the current OS.
-fn relative_posix_path(base_path: &String, filename: &String) -> String {
+fn relative_posix_path(base_path: &str, filename: &str) -> String {
     let normalized_base_path = convert_path_to_posix(base_path);
     let normalized_filename = convert_path_to_posix(filename);
     let relative_filename = diff_paths(normalized_filename, normalized_base_path)
@@ -200,7 +200,7 @@ fn relative_posix_path(base_path: &String, filename: &String) -> String {
         .map(|component| component.as_os_str().to_str().unwrap())
         .collect::<Vec<&str>>();
 
-    return path_parts.join("/");
+    path_parts.join("/")
 }
 
 /// Returns the path converted to a POSIX path (naive approach).
@@ -208,15 +208,12 @@ fn relative_posix_path(base_path: &String, filename: &String) -> String {
 /// For example:
 /// - "C:\foo\bar" -> "c/foo/bar"
 /// - "/foo/bar" -> "/foo/bar"
-fn convert_path_to_posix(path: &String) -> String {
+fn convert_path_to_posix(path: &str) -> String {
     lazy_static! {
         static ref PATH_REPLACEMENT_REGEX: Regex = Regex::new(r":\\|\\").unwrap();
     }
 
-    return PATH_REPLACEMENT_REGEX
-        .replace_all(path, "/")
-        .to_string()
-        .to_owned();
+    PATH_REPLACEMENT_REGEX.replace_all(path, "/").to_string()
 }
 
 #[cfg(test)]
@@ -328,7 +325,7 @@ mod tests {
     #[test]
     fn test_relative_path_unix() {
         assert_eq!(
-            relative_posix_path(&String::from("/foo/"), &String::from("/bar/baz.txt")),
+            relative_posix_path("/foo/", "/bar/baz.txt"),
             "../bar/baz.txt"
         );
     }
@@ -336,24 +333,18 @@ mod tests {
     #[test]
     fn test_relative_path_windows() {
         assert_eq!(
-            relative_posix_path(&String::from(r"C:\foo\"), &String::from(r"C:\bar\baz.txt")),
+            relative_posix_path(r"C:\foo\", r"C:\bar\baz.txt"),
             "../bar/baz.txt"
         );
     }
 
     #[test]
     fn test_convert_unix_path() {
-        assert_eq!(
-            convert_path_to_posix(&String::from(r"/foo/bar")),
-            "/foo/bar"
-        );
+        assert_eq!(convert_path_to_posix(r"/foo/bar"), "/foo/bar");
     }
 
     #[test]
     fn test_convert_windows_path() {
-        assert_eq!(
-            convert_path_to_posix(&String::from(r"C:\foo\bar")),
-            "C/foo/bar"
-        );
+        assert_eq!(convert_path_to_posix(r"C:\foo\bar"), "C/foo/bar");
     }
 }


### PR DESCRIPTION
Due to the rust Path  module (and all other similar crates I've found) not being able to handle windows paths in the webassembly version (seems to work only on windows, see: https://github.com/rust-lang/rust/issues/66621) I've implemented a simple naive conversion of filepaths to be posix-like even if the input is a windows path

might fix #6 

@jantimon I was not able to test this in our next-js project, as npm via file:// did not actually work for imports, but the plugin did run