### PR TITLE
handle constant case

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -134,9 +134,13 @@ function getNameByUsage(path) {
   return "";
 }
 
-/** @param {string} val */
+/** @param {string} val*/
 function dashed(val) {
-  return val.replace(/([A-Z])/g, (_, c) => `-${c.toLowerCase()}`);
+  /** handle camelCase and CONSTANT_CASE */
+  return val
+  .replace(/([0-9a-z])([A-Z])/g, "$1-$2")
+  .toLowerCase()
+  .replace(/_/g, "-");
 }
 
 /** @type {WeakMap<babel.PluginPass, string>} */


### PR DESCRIPTION
Currently we only support camelCasing for variable names.
Variables with the name SOME_COLOR_20_PERCENT_OPACITY are formatted into an unreadable format: "-s-o-m-e--c-o-l-o-r-20--p-e-r-c-e-n-t--o-p-a-c-i-t-y"
with the new change it gets formatted into "some-color-20-percent-opacity" while camelCase is still supported.
