### PR TITLE
perf(swc): enable profile with improved rustc options

### DIFF
--- a/swc/Cargo.toml
+++ b/swc/Cargo.toml
@@ -5,9 +5,9 @@ members = [
 ]
 
 [profile.release]
-# Uncomment to achieve smallest possible binary size (may require more experimentation).
-# Disclaimer: measure effects on runtime, results can be surprising.
-# strip = "debuginfo"
-# codegen-units = 1
-# lto = true
-# opt-level = "z"
+# This profile results in small binary size with acceptable impact on
+# performance, but there may well be further optimizations to be had.
+strip = "debuginfo"
+codegen-units = 1
+lto = true
+opt-level = "z"


### PR DESCRIPTION
With these options we can reduce binary size from 4.22 MB to 1.29 MB with a negligible impact on performance.

| benchmark                       | before    | after     |
|---------------------------------|-----------|-----------|
| visitor styledPage              | 6.6678 µs | 7.7369 µs |
| visitor styledPage display_name | 8.1601 µs | 9.6053 µs |
| visitor nested                  | 3.2131 µs | 3.8598 µs |
| visitor nested display_name     | 4.2659 µs | 5.1917 µs |
| short filename hash             | 68.245 ns | 47.291 ns |
| longer filename hash            | 78.917 ns | 91.891 ns |

Hashing suffers most, probably because `opt-level=z` turns off loop vectorization. I'm pretty sure though that when using SWC plugins for code transformation there are other operations involved that take orders of magnitude more time than the execution of our Wasm module, so the tradeoff seems extremely attractive.