### PR TITLE
Fix convert_path_to_posix for mixed paths

### DIFF
--- a/examples/styled-components/next-env.d.ts
+++ b/examples/styled-components/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-variable",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "define CSS custom properties (variables) in JS",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/swc/swc-plugin-css-variable/src/lib.rs
+++ b/swc/swc-plugin-css-variable/src/lib.rs
@@ -65,7 +65,7 @@ fn relative_posix_path(base_path: &str, filename: &str) -> String {
 /// - "/foo/bar" -> "/foo/bar"
 fn convert_path_to_posix(path: &str) -> String {
     lazy_static! {
-        static ref PATH_REPLACEMENT_REGEX: Regex = Regex::new(r":\\|\\").unwrap();
+        static ref PATH_REPLACEMENT_REGEX: Regex = Regex::new(r":\\|\\|:/").unwrap();
     }
 
     PATH_REPLACEMENT_REGEX.replace_all(path, "/").to_string()
@@ -88,6 +88,14 @@ mod tests {
         assert_eq!(
             relative_posix_path(r"C:\foo\", r"C:\bar\baz.txt"),
             "../bar/baz.txt"
+        );
+    }
+
+    #[test]
+    fn test_relative_path_windows_forward_slash() {
+        assert_eq!(
+            relative_posix_path(r"E:\foo", "E:/foo/bar/file.tsx"),
+            "bar/file.tsx"
         );
     }
 


### PR DESCRIPTION
Fixes the regex used in the convert_path_to_posix method for forward slashed paths (C:/foo/bar).

This fix should be released for V4 and V5 of the package.